### PR TITLE
Remove run.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,9 @@ A real time data processing pipeline with these services:
  - Console logger - This destination service simply logs the data being recieved to the console. Adapt it to suit your needs.
 
 We have also included a `docker-compose.yml` file so you can run the whole pipeline locally, including the message broker.
+
+# Running Locally
+
+```sh
+docker compose up --build
+```

--- a/run.bat
+++ b/run.bat
@@ -1,3 +1,0 @@
-@echo off
-
-docker-compose up -d --build --remove-orphans

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-# Run Docker Compose
-docker-compose up -d --build --remove-orphans


### PR DESCRIPTION
Removing the `run.sh/run.bat` scripts.

This could be controversial but...

...I think they harm more than help. If you call `run.sh` then the only feedback you get is:

```sh
 ...
 ✔ Container redpanda          Started
 ✔ Container redpanda-console  Started
 ✔ Container csv-data-source   Started
 ✔ Container name-counter      Started
 ✔ Container console-logger    Started
```

You now have some background processes running and no advice on how to inspect them (or even that you should). If we add to the README that the user should run the `docker compose` command themselves then they get a *much* better sense that something is happening:

```sh
...
console-logger    | -~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~
console-logger    | This is one row of your data
console-logger    | Transform it here or publish it to an external data store
console-logger    | {'Timestamp': 1713430789262210845, 'Number': 100, 'Name': 'Joseph', 'count': 2}
console-logger    | -~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~
...
```

Now I can see some data, it's active, (I know something is running and busy). The sense that this template "does something" is restored.
