### PR TITLE
Splitting the dockerfiles into multi-stage builds.

### DIFF
--- a/console logger/dockerfile
+++ b/console logger/dockerfile
@@ -1,10 +1,24 @@
-FROM python:3.11.1-slim-buster
+# Dependency-building stage.
+FROM python:3.11.1-slim-buster AS build
 
 ENV DEBIAN_FRONTEND="noninteractive"
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONIOENCODING=UTF-8
 
 WORKDIR /app
+RUN python3 -m venv env
+ENV PATH="env/bin:$PATH"
+
+COPY requirements.txt .
+RUN python3 -m pip install -r requirements.txt
+
+# Runtime stage.
+FROM python:3.11.1-slim-buster AS runtime
+
+WORKDIR /app
+COPY --from=build /app/env /app/env
+ENV PATH="env/bin:$PATH"
+
 COPY . .
-RUN find | grep requirements.txt | xargs -I '{}' python3 -m pip install -r '{}' --extra-index-url https://pkgs.dev.azure.com/quix-analytics/53f7fe95-59fe-4307-b479-2473b96de6d1/_packaging/public/pypi/simple/
-ENTRYPOINT ["python3", "main.py"]
+
+ENTRYPOINT ["env/bin/python3", "main.py"]

--- a/csv data source/dockerfile
+++ b/csv data source/dockerfile
@@ -1,10 +1,24 @@
-FROM python:3.11.1-slim-buster
+# Dependency-building stage.
+FROM python:3.11.1-slim-buster AS build
 
 ENV DEBIAN_FRONTEND="noninteractive"
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONIOENCODING=UTF-8
 
 WORKDIR /app
+RUN python3 -m venv env
+ENV PATH="env/bin:$PATH"
+
+COPY requirements.txt .
+RUN python3 -m pip install -r requirements.txt
+
+# Runtime stage.
+FROM python:3.11.1-slim-buster AS runtime
+
+WORKDIR /app
+COPY --from=build /app/env /app/env
+ENV PATH="env/bin:$PATH"
+
 COPY . .
-RUN find | grep requirements.txt | xargs -I '{}' python3 -m pip install -r '{}' --extra-index-url https://pkgs.dev.azure.com/quix-analytics/53f7fe95-59fe-4307-b479-2473b96de6d1/_packaging/public/pypi/simple/
-ENTRYPOINT ["python3", "main.py"]
+
+ENTRYPOINT ["env/bin/python3", "main.py"]

--- a/name counter/dockerfile
+++ b/name counter/dockerfile
@@ -1,10 +1,25 @@
-FROM python:3.11.1-slim-buster
+# Dependency-building stage.
+FROM python:3.11.1-slim-buster AS build
 
 ENV DEBIAN_FRONTEND="noninteractive"
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONIOENCODING=UTF-8
 
 WORKDIR /app
+RUN python3 -m venv env
+ENV PATH="env/bin:$PATH"
+
+COPY requirements.txt .
+RUN python3 -m pip install -r requirements.txt
+
+
+# Runtime stage.
+FROM python:3.11.1-slim-buster AS runtime
+
+WORKDIR /app
+COPY --from=build /app/env /app/env
+ENV PATH="env/bin:$PATH"
+
 COPY . .
-RUN find | grep requirements.txt | xargs -I '{}' python3 -m pip install -r '{}' --extra-index-url https://pkgs.dev.azure.com/quix-analytics/53f7fe95-59fe-4307-b479-2473b96de6d1/_packaging/public/pypi/simple/
-ENTRYPOINT ["python3", "main.py"]
+
+ENTRYPOINT ["env/bin/python3", "main.py"]


### PR DESCRIPTION
Previously if you edited `main.py` and rebuilt the image, you'd redownload all the python deps again, needlessly.

Now you can change `main.py` without triggering a needless `pip install`. It's a _much_ snappier development experience.